### PR TITLE
Convert to using python3 & force HTML for escape characters

### DIFF
--- a/category.xml
+++ b/category.xml
@@ -1,0 +1,115 @@
+<!--Ref: https://tvheadend.org/boards/12/topics/9892?r=26317-->
+<!--Ref: https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.16.01_60/en_300468v011601p.pdf p54-56-->
+<etsi version="1.16.1" lang="default">
+  <content level1="0x1" name="Movie/Drama">
+    <nibble level2="default">movie</nibble>
+    <nibble level2="0x0">movie/drama</nibble>
+    <nibble level2="0x1">detective/thriller</nibble>
+    <nibble level2="0x2">adventure/western/war"</nibble>
+    <nibble level2="0x3">science fiction/fantasy/horror"</nibble>
+    <nibble level2="0x4">comedy</nibble>
+    <nibble level2="0x5">soap/melodrama/folkloric</nibble>
+    <nibble level2="0x6">romance</nibble>
+    <nibble level2="0x7">serious/classical/religious/historical movie/drama</nibble>
+    <nibble level2="0x8">adult movie/drama</nibble>
+  </content>
+  <content level1="0x2" name="News/Current affairs">
+    <nibble level2="default">news</nibble>
+    <nibble level2="0x0">news/current affairs</nibble>
+    <nibble level2="0x1">news/weather report</nibble>
+    <nibble level2="0x2">news magazine</nibble>
+    <nibble level2="0x3">documentary</nibble>
+    <nibble level2="0x4">discussion/interview/debate</nibble>
+  </content>
+  <content level1="0x3" name="Show/Game show">
+    <nibble level2="default">talk</nibble>
+    <nibble level2="0x0">show/game show</nibble>
+    <nibble level2="0x1">game show/quiz/contest</nibble>
+    <nibble level2="0x2">variety show</nibble>
+    <nibble level2="0x3">talk show</nibble>
+  </content>
+  <content level1="0x4" name="Sports">
+    <nibble level2="default">sports</nibble>
+    <nibble level2="0x0">sports</nibble>
+    <nibble level2="0x1">special events (Olympic Games, World Cup, etc.)</nibble>
+    <nibble level2="0x2">sports magazines</nibble>
+    <nibble level2="0x3">football/soccer</nibble>
+    <nibble level2="0x4">tennis/squash</nibble>
+    <nibble level2="0x5">team sports (excluding football)</nibble>
+    <nibble level2="0x6">athletics</nibble>
+    <nibble level2="0x7">motor sport</nibble>
+    <nibble level2="0x8">water sport</nibble>
+    <nibble level2="0x9">winter sports</nibble>
+    <nibble level2="0xA">equestrian</nibble>
+    <nibble level2="0xB">martial sports</nibble>
+  </content>
+  <content level1="0x5" name="Children's/Youth programmes">
+    <nibble level2="default">family</nibble>
+    <nibble level2="0x0">children's/youth programmes</nibble>
+    <nibble level2="0x1">pre-school children's programmes</nibble>
+    <nibble level2="0x2">entertainment programmes for 6 to 14</nibble>
+    <nibble level2="0x3">entertainment programmes for 10 to 16</nibble>
+    <nibble level2="0x4">informational/educational/school programmes</nibble>
+    <nibble level2="0x5">cartoons/puppets</nibble>
+  </content>
+  <content level1="0x6" name="Music/Ballet/Dance">
+    <nibble level2="0x0">music/ballet/dance</nibble>
+    <nibble level2="0x1">rock/pop</nibble>
+    <nibble level2="0x2">serious music/classical music</nibble>
+    <nibble level2="0x3">folk/traditional music</nibble>
+    <nibble level2="0x4">jazz</nibble>
+    <nibble level2="0x5">musical/opera</nibble>
+    <nibble level2="0x6">ballet</nibble>
+  </content>
+  <content level1="0x7" name="Arts/Culture (without music)">
+    <nibble level2="0x0">arts/culture (without music)</nibble>
+    <nibble level2="0x1">performing arts</nibble>
+    <nibble level2="0x2">fine arts</nibble>
+    <nibble level2="0x3">religion</nibble>
+    <nibble level2="0x4">popular culture/traditional arts</nibble>
+    <nibble level2="0x5">literature</nibble>
+    <nibble level2="0x6">film/cinema</nibble>
+    <nibble level2="0x7">experimental film/video</nibble>
+    <nibble level2="0x8">broadcasting/press</nibble>
+    <nibble level2="0x9">new media</nibble>
+    <nibble level2="0xA">arts/culture magazines</nibble>
+    <nibble level2="0xB">fashion</nibble>
+  </content>
+  <content level1="0x8" name="Social/Political issues/Economics">
+    <nibble level2="0x0">social/political issues/economics</nibble>
+    <nibble level2="0x1">magazines/reports/documentary</nibble>
+    <nibble level2="0x2">economics/social advisory</nibble>
+    <nibble level2="0x3">remarkable people</nibble>
+  </content>
+  <content level1="0x9" name="Education/Science/Factual topics">
+    <nibble level2="0x0">education/science/factual topics</nibble>
+    <nibble level2="0x1">nature/animals/environment</nibble>
+    <nibble level2="0x2">technology/natural sciences</nibble>
+    <nibble level2="0x3">medicine/physiology/psychology</nibble>
+    <nibble level2="0x4">foreign countries/expeditions</nibble>
+    <nibble level2="0x5">social/spiritual sciences</nibble>
+    <nibble level2="0x6">further education</nibble>
+    <nibble level2="0x7">languages</nibble>
+  </content>
+  <content level1="0xA" name="Leisure hobbies">
+    <nibble level2="0x0">leisure hobbies</nibble>
+    <nibble level2="0x1">tourism/travel</nibble>
+    <nibble level2="0x2">handicraft</nibble>
+    <nibble level2="0x3">motoring</nibble>
+    <nibble level2="0x4">fitness and health</nibble>
+    <nibble level2="0x5">cooking</nibble>
+    <nibble level2="0x6">advertisement/shopping</nibble>
+    <nibble level2="0x7">gardening</nibble>
+  </content>
+  <content level1="0xB" name="Special characteristics">
+    <nibble level2="0x0">original language</nibble>
+    <nibble level2="0x1">black and white</nibble>
+    <nibble level2="0x2">unpublished</nibble>
+    <nibble level2="0x3">live broadcast</nibble>
+    <nibble level2="0x4">plano-stereoscopic</nibble>
+    <nibble level2="0x5">local or regional</nibble>
+  </content>
+  <content level1="0xC" name="Adult">
+    <nibble level2="0x0">adult</nibble>
+  </content>
+</etsi>

--- a/category_fr.xml
+++ b/category_fr.xml
@@ -1,0 +1,115 @@
+<!--Ref: https://tvheadend.org/boards/12/topics/9892?r=26317-->
+<!--Ref: https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.16.01_60/en_300468v011601p.pdf p54-56-->
+<etsi version="1.16.1" lang="fr_CA">
+  <content level1="0x1" name="Movie/Drama">
+    <nibble level2="default">movie</nibble>
+    <nibble level2="0x0">movie/drama</nibble>
+    <nibble level2="0x1">detective/thriller</nibble>
+    <nibble level2="0x2">adventure/western/war"</nibble>
+    <nibble level2="0x3">science fiction/fantasy/horror"</nibble>
+    <nibble level2="0x4">comedy</nibble>
+    <nibble level2="0x5">soap/melodrama/folkloric</nibble>
+    <nibble level2="0x6">romance</nibble>
+    <nibble level2="0x7">serious/classical/religious/historical movie/drama</nibble>
+    <nibble level2="0x8">adult movie/drama</nibble>
+  </content>
+  <content level1="0x2" name="News/Current affairs">
+    <nibble level2="default">news</nibble>
+    <nibble level2="0x0">news/current affairs</nibble>
+    <nibble level2="0x1">news/weather report</nibble>
+    <nibble level2="0x2">news magazine</nibble>
+    <nibble level2="0x3">documentary</nibble>
+    <nibble level2="0x4">discussion/interview/debate</nibble>
+  </content>
+  <content level1="0x3" name="Show/Game show">
+    <nibble level2="default">talk</nibble>
+    <nibble level2="0x0">show/game show</nibble>
+    <nibble level2="0x1">game show/quiz/contest</nibble>
+    <nibble level2="0x2">variety show</nibble>
+    <nibble level2="0x3">talk show</nibble>
+  </content>
+  <content level1="0x4" name="Sports">
+    <nibble level2="default">sports</nibble>
+    <nibble level2="0x0">sports</nibble>
+    <nibble level2="0x1">special events (Olympic Games, World Cup, etc.)</nibble>
+    <nibble level2="0x2">sports magazines</nibble>
+    <nibble level2="0x3">football/soccer</nibble>
+    <nibble level2="0x4">tennis/squash</nibble>
+    <nibble level2="0x5">team sports (excluding football)</nibble>
+    <nibble level2="0x6">athletics</nibble>
+    <nibble level2="0x7">motor sport</nibble>
+    <nibble level2="0x8">water sport</nibble>
+    <nibble level2="0x9">winter sports</nibble>
+    <nibble level2="0xA">equestrian</nibble>
+    <nibble level2="0xB">martial sports</nibble>
+  </content>
+  <content level1="0x5" name="Children's/Youth programmes">
+    <nibble level2="default">family</nibble>
+    <nibble level2="0x0">children's/youth programmes</nibble>
+    <nibble level2="0x1">pre-school children's programmes</nibble>
+    <nibble level2="0x2">entertainment programmes for 6 to 14</nibble>
+    <nibble level2="0x3">entertainment programmes for 10 to 16</nibble>
+    <nibble level2="0x4">informational/educational/school programmes</nibble>
+    <nibble level2="0x5">cartoons/puppets</nibble>
+  </content>
+  <content level1="0x6" name="Music/Ballet/Dance">
+    <nibble level2="0x0">music/ballet/dance</nibble>
+    <nibble level2="0x1">rock/pop</nibble>
+    <nibble level2="0x2">serious music/classical music</nibble>
+    <nibble level2="0x3">folk/traditional music</nibble>
+    <nibble level2="0x4">jazz</nibble>
+    <nibble level2="0x5">musical/opera</nibble>
+    <nibble level2="0x6">ballet</nibble>
+  </content>
+  <content level1="0x7" name="Arts/Culture (without music)">
+    <nibble level2="0x0">arts/culture (without music)</nibble>
+    <nibble level2="0x1">performing arts</nibble>
+    <nibble level2="0x2">fine arts</nibble>
+    <nibble level2="0x3">religion</nibble>
+    <nibble level2="0x4">popular culture/traditional arts</nibble>
+    <nibble level2="0x5">literature</nibble>
+    <nibble level2="0x6">film/cinema</nibble>
+    <nibble level2="0x7">experimental film/video</nibble>
+    <nibble level2="0x8">broadcasting/press</nibble>
+    <nibble level2="0x9">new media</nibble>
+    <nibble level2="0xA">arts/culture magazines</nibble>
+    <nibble level2="0xB">fashion</nibble>
+  </content>
+  <content level1="0x8" name="Social/Political issues/Economics">
+    <nibble level2="0x0">social/political issues/economics</nibble>
+    <nibble level2="0x1">magazines/reports/documentary</nibble>
+    <nibble level2="0x2">economics/social advisory</nibble>
+    <nibble level2="0x3">remarkable people</nibble>
+  </content>
+  <content level1="0x9" name="Education/Science/Factual topics">
+    <nibble level2="0x0">education/science/factual topics</nibble>
+    <nibble level2="0x1">nature/animals/environment</nibble>
+    <nibble level2="0x2">technology/natural sciences</nibble>
+    <nibble level2="0x3">medicine/physiology/psychology</nibble>
+    <nibble level2="0x4">foreign countries/expeditions</nibble>
+    <nibble level2="0x5">social/spiritual sciences</nibble>
+    <nibble level2="0x6">further education</nibble>
+    <nibble level2="0x7">languages</nibble>
+  </content>
+  <content level1="0xA" name="Leisure hobbies">
+    <nibble level2="0x0">leisure hobbies</nibble>
+    <nibble level2="0x1">tourism/travel</nibble>
+    <nibble level2="0x2">handicraft</nibble>
+    <nibble level2="0x3">motoring</nibble>
+    <nibble level2="0x4">fitness and health</nibble>
+    <nibble level2="0x5">cooking</nibble>
+    <nibble level2="0x6">advertisement/shopping</nibble>
+    <nibble level2="0x7">gardening</nibble>
+  </content>
+  <content level1="0xB" name="Special characteristics">
+    <nibble level2="0x0">original language</nibble>
+    <nibble level2="0x1">black and white</nibble>
+    <nibble level2="0x2">unpublished</nibble>
+    <nibble level2="0x3">live broadcast</nibble>
+    <nibble level2="0x4">plano-stereoscopic</nibble>
+    <nibble level2="0x5">local or regional</nibble>
+  </content>
+  <content level1="0xC" name="Adult">
+    <nibble level2="0x0">adult</nibble>
+  </content>
+</etsi>

--- a/channel.xml
+++ b/channel.xml
@@ -1,0 +1,8 @@
+<channel version="1">
+  <channel id="CBFTDT">fr_CA</channel>
+  <channel id="CFJPDT">fr_CA</channel>
+  <channel id="CFTMDT">fr_CA</channel>
+  <channel id="CHLTDT">fr_CA</channel>
+  <channel id="CIVMDT">fr_CA</channel>
+  <channel id="CKSHDT">fr_CA</channel>
+</channels>

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -371,8 +371,11 @@ def mainRun(userdata):
                                 if epgenre != '0':
                                     if edict['epfilter'] is not None and edict['epgenres'] is not None:
                                         genreNewList = genreSort(edict['epfilter'], edict['epgenres'])
-                                        for genre in genreNewList:
-                                            fh.write("\t\t<category lang=\"" + lang + "\">" + genre + "</category>\n")
+                                    elif edict['epfilter'] is not None:
+                                        genreNewList = edict['epfilter']
+                                    if genreNewList is not "":
+                                        for category in genreNewList:
+                                            fh.write("\t\t<category lang=\"" + lang + "\">" + category.replace('filter-','') + "</category>\n")
                                 fh.write("\t</programme>\n")
                                 episodeCount += 1
                         except Exception as e:

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -336,6 +336,8 @@ def mainRun(userdata):
                                 if xdesc == 'false':
                                     if edict['epdesc'] is not None:
                                         fh.write('\t\t<desc lang=\"' + lang + '\">' + convHTML(edict['epdesc']) + '</desc>\n')
+                                if edict['eplength'] is not None:
+                                    fh.write('\t\t<length units="minutes">' + edict['eplength'] + '</length>\n')
                                 if edict['epsn'] is not None and edict['epen'] is not None:
                                     fh.write("\t\t<episode-num system=\"onscreen\">" + 'S' + edict['epsn'].zfill(2) + 'E' + edict['epen'].zfill(2) + "</episode-num>\n")
                                     fh.write("\t\t<episode-num system=\"xmltv_ns\">" + str(int(edict['epsn'])-1) +  "." + str(int(edict['epen'])-1) + ".</episode-num>\n")

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -176,6 +176,11 @@ def mainRun(userdata):
         data = data.replace('>','&gt;')
         return data;
 
+    def convTitleExcept(data):
+        exception = "CTV CW HD ION ION: NHK PBS TV TVA"
+        data = " ".join([word.title() if word not in exception else word for word in data.split(" ")])
+        return data;
+
     def savepage(fn, data):
         if not os.path.exists(cacheDir):
             os.mkdir(cacheDir)
@@ -288,7 +293,9 @@ def mainRun(userdata):
                 if 'chnum' in scheduleSort[station] and 'chfcc' in scheduleSort[station]:
                     xchnum = scheduleSort[station]['chnum']
                     xchfcc = scheduleSort[station]['chfcc']
+                    xchnam = scheduleSort[station]['chnam']
                     fh.write('\t\t<display-name>' + xchnum + ' ' + convHTML(xchfcc) + '</display-name>\n')
+                    fh.write('\t\t<display-name>' + convTitleExcept(xchnam) + '</display-name>\n')
                     fh.write('\t\t<display-name>' + convHTML(xchfcc) + '</display-name>\n')
                     fh.write('\t\t<display-name>' + xchnum + '</display-name>\n')
                 elif 'chfcc' in scheduleSort[station]:
@@ -416,12 +423,14 @@ def mainRun(userdata):
                 if stationList is not None:
                     if skey in stationList:
                         schedule[skey] = {}
-                        chName = station.get('callSign')
-                        schedule[skey]['chfcc'] = chName
+                        chSign = station.get('callSign')
+                        chName = station.get('affiliateName')
+                        schedule[skey]['chfcc'] = chSign
+                        schedule[skey]['chnam'] = chName
                         schedule[skey]['chicon'] = station.get('thumbnail').split('?')[0]
                         chnumStart = station.get('channelNo')
-                        if '.' not in chnumStart and chmatch == 'true' and chName is not None:
-                            chsub = re.search('(\d+)$', chName)
+                        if '.' not in chnumStart and chmatch == 'true' and chSign is not None:
+                            chsub = re.search('(\d+)$', chSign)
                             if chsub is not None:
                                 chnumUpdate = chnumStart + '.' + chsub.group(0)
                             else:
@@ -436,12 +445,14 @@ def mainRun(userdata):
                                 schedule[skey]['chtvh'] = None
                 else:
                     schedule[skey] = {}
-                    chName = station.get('callSign')
-                    schedule[skey]['chfcc'] = chName
+                    chSign = station.get('callSign')
+                    chName = station.get('affiliateName')
+                    schedule[skey]['chfcc'] = chSign
+                    schedule[skey]['chnam'] = chName
                     schedule[skey]['chicon'] = station.get('thumbnail').split('?')[0]
                     chnumStart = station.get('channelNo')
-                    if '.' not in chnumStart and chmatch == 'true' and chName is not None:
-                        chsub = re.search('(\d+)$', chName)
+                    if '.' not in chnumStart and chmatch == 'true' and chSign is not None:
+                        chsub = re.search('(\d+)$', chSign)
                         if chsub is not None:
                             chnumUpdate = chnumStart + '.' + chsub.group(0)
                         else:

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -359,11 +359,18 @@ def mainRun(userdata):
                                     if edict['epoad'] is not None and int(edict['epoad']) > 0:
                                         fh.write("start=\"" + convTime(edict['epoad']) + " " + TZoffset + "\"")
                                     fh.write(" />\n")
+                                if edict['eptags'] is not None:
+                                    if 'CC' in edict['eptags']:
+                                        fh.write('\t\t<subtitles type="teletext" />\n')
                                 if edict['epflag'] is not None:
-                                    if 'New' in edict['epflag']:
-                                        fh.write("\t\t<new />\n")
+                                    if 'Finale' in edict['epflag']:
+                                        fh.write("\t\t<last-chance />\n")
                                     if 'Live' in edict['epflag']:
                                         fh.write("\t\t<live />\n")
+                                    if 'New' in edict['epflag']:
+                                        fh.write("\t\t<new />\n")
+                                    if 'Finale' in edict['epflag']:
+                                        fh.write("\t\t<premiere />\n")
                                 if edict['eprating'] is not None:
                                     fh.write('\t\t<rating>\n\t\t\t<value>' + edict['eprating'] + '</value>\n\t\t</rating>\n')
                                 if edict['epstar'] is not None:

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # zap2epg tv schedule grabber for kodi
 ################################################################################
 #   This program is free software: you can redistribute it and/or modify
@@ -14,7 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import base64
 import codecs
 import time
@@ -110,11 +112,11 @@ def mainRun(userdata):
         channels_url = tvhUrlBase + '/api/channel/grid?all=1&limit=999999999&sort=name&filter=[{"type":"boolean","value":true,"field":"enabled"}]'
         if usern is not None and passw is not None:
             logging.info('Adding Tvheadend username and password to request url...')
-            request = urllib2.Request(channels_url)
+            request = urllib.request.Request(channels_url)
             request.add_header('Authorization', b'Basic ' + base64.b64encode(usern + b':' + passw))
-            response = urllib2.urlopen(request)
+            response = urllib.request.urlopen(request)
         else:
-            response = urllib2.urlopen(channels_url)
+            response = urllib.request.urlopen(channels_url)
         try:
             logging.info('Accessing Tvheadend channel list from: %s', tvhUrlBase)
             channels = json.load(response)
@@ -123,7 +125,7 @@ def mainRun(userdata):
                 channelNum = ch['number']
                 tvhMatchDict[channelNum] = channelName
             logging.info('%s Tvheadend channels found...', str(len(tvhMatchDict)))
-        except urllib2.HTTPError as e:
+        except urllib.error.HTTPError as e:
             logging.exception('Exception: tvhMatch - %s', e.strerror)
             pass
 
@@ -140,7 +142,7 @@ def mainRun(userdata):
                             try:
                                 os.remove(fn)
                                 logging.info('Deleting old cache: %s', entry)
-                            except OSError, e:
+                            except OSError as e:
                                 logging.warn('Error Deleting: %s - %s.' % (e.filename, e.strerror))
         except Exception as e:
             logging.exception('Exception: deleteOldCache - %s', e.strerror)
@@ -158,7 +160,7 @@ def mainRun(userdata):
                             try:
                                 os.remove(fn)
                                 logging.info('Deleting old show cache: %s', entry)
-                            except OSError, e:
+                            except OSError as e:
                                 logging.warn('Error Deleting: %s - %s.' % (e.filename, e.strerror))
         except Exception as e:
             logging.exception('Exception: deleteOldshowCache - %s', e.strerror)
@@ -267,9 +269,9 @@ def mainRun(userdata):
         try:
             logging.info('Writing Stations to xmltv.xml file...')
             try:
-                scheduleSort = OrderedDict(sorted(schedule.iteritems(), key=lambda x: int(x[1]['chnum'])))
+                scheduleSort = OrderedDict(sorted(iter(schedule.items()), key=lambda x: int(x[1]['chnum'])))
             except:
-                scheduleSort = OrderedDict(sorted(schedule.iteritems(), key=lambda x: x[1]['chfcc']))
+                scheduleSort = OrderedDict(sorted(iter(schedule.items()), key=lambda x: x[1]['chfcc']))
             for station in scheduleSort:
                 fh.write('\t<channel id=\"' + station + '.zap2epg\">\n')
                 if 'chtvh' in scheduleSort[station] and scheduleSort[station]['chtvh'] is not None:
@@ -533,8 +535,8 @@ def mainRun(userdata):
                                     url = 'https://tvlistings.zap2it.com/api/program/overviewDetails'
                                     data = 'programSeriesID=' + EPseries
                                     try:
-                                        URLcontent = urllib2.Request(url, data=data)
-                                        JSONcontent = urllib2.urlopen(URLcontent).read()
+                                        URLcontent = urllib.request.Request(url, data=data)
+                                        JSONcontent = urllib.request.urlopen(URLcontent).read()
                                         if JSONcontent:
                                             with open(fileDir,"wb+") as f:
                                                 f.write(JSONcontent)
@@ -544,7 +546,7 @@ def mainRun(userdata):
                                             time.sleep(1)
                                             retry -= 1
                                             logging.warn('Retry downloading missing details data for: %s', EPseries)
-                                    except urllib2.URLError, e:
+                                    except urllib.error.URLError as e:
                                         time.sleep(1)
                                         retry -= 1
                                         logging.warn('Retry downloading details data for: %s  -  %s', EPseries, e)
@@ -583,7 +585,7 @@ def mainRun(userdata):
                                                                 os.remove(fileDir)
                                                                 logging.info('Deleting %s due to TBA listings', filename)
                                                                 showList.remove(edict['epseries'])
-                                                            except OSError, e:
+                                                            except OSError as e:
                                                                 logging.warn('Error Deleting: %s - %s.' % (e.filename, e.strerror))
                                                 except Exception as e:
                                                     logging.exception('Could not parse TBAcheck for: %s - %s', episode, e)
@@ -616,14 +618,14 @@ def mainRun(userdata):
             prog = ""
             plot= ""
             descsort = ""
-            bullet = u"\u2022 "
-            hyphen = u"\u2013 "
+            bullet = "\u2022 "
+            hyphen = "\u2013 "
             newLine = "\n"
             space = " "
-            colon = u"\u003A "
-            vbar = u"\u007C "
-            slash = u"\u2215 "
-            comma = u"\u002C "
+            colon = "\u003A "
+            vbar = "\u007C "
+            slash = "\u2215 "
+            comma = "\u002C "
 
             def getSortName(opt):
                 return {
@@ -759,7 +761,7 @@ def mainRun(userdata):
                 try:
                     logging.info('Downloading guide data for: %s', str(gridtime))
                     url = 'http://tvlistings.zap2it.com/api/grid?lineupId=&timespan=3&headendId=' + lineupcode + '&country=' + country + '&device=' + device + '&postalCode=' + zipcode + '&time=' + str(gridtime) + '&pref=-&userId=-'
-                    saveContent = urllib2.urlopen(url).read()
+                    saveContent = urllib.request.urlopen(url).read()
                     savepage(fileDir, saveContent)
                 except:
                     logging.warn('Could not download guide data for: %s', str(gridtime))
@@ -777,7 +779,7 @@ def mainRun(userdata):
                         try:
                             os.remove(fileDir)
                             logging.info('Deleting %s due to TBA listings', filename)
-                        except OSError, e:
+                        except OSError as e:
                             logging.warn('Error Deleting: %s - %s.' % (e.filename, e.strerror))
                 except:
                     logging.warn('JSON file error for: %s - deleting file', filename)

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -168,6 +168,14 @@ def mainRun(userdata):
     def convTime(t):
         return time.strftime("%Y%m%d%H%M%S",time.localtime(int(t)))
 
+    def convHTML(data):
+        data = data.replace('&','&amp;')
+        data = data.replace('"','&quot;')
+        data = data.replace("'",'&apos;')
+        data = data.replace('<','&lt;')
+        data = data.replace('>','&gt;')
+        return data;
+
     def savepage(fn, data):
         if not os.path.exists(cacheDir):
             os.mkdir(cacheDir)
@@ -275,17 +283,17 @@ def mainRun(userdata):
             for station in scheduleSort:
                 fh.write('\t<channel id=\"' + station + '.zap2epg\">\n')
                 if 'chtvh' in scheduleSort[station] and scheduleSort[station]['chtvh'] is not None:
-                    xchtvh = re.sub('&','&amp;',scheduleSort[station]['chtvh'])
+                    xchtvh = convHTML(scheduleSort[station]['chtvh'])
                     fh.write('\t\t<display-name>' + xchtvh + '</display-name>\n')
                 if 'chnum' in scheduleSort[station] and 'chfcc' in scheduleSort[station]:
                     xchnum = scheduleSort[station]['chnum']
                     xchfcc = scheduleSort[station]['chfcc']
-                    fh.write('\t\t<display-name>' + xchnum + ' ' + re.sub('&','&amp;',xchfcc) + '</display-name>\n')
-                    fh.write('\t\t<display-name>' + re.sub('&','&amp;',xchfcc) + '</display-name>\n')
+                    fh.write('\t\t<display-name>' + xchnum + ' ' + convHTML(xchfcc) + '</display-name>\n')
+                    fh.write('\t\t<display-name>' + convHTML(xchfcc) + '</display-name>\n')
                     fh.write('\t\t<display-name>' + xchnum + '</display-name>\n')
                 elif 'chfcc' in scheduleSort[station]:
                     xchnum = scheduleSort[station]['chfcc']
-                    fh.write('\t\t<display-name>' + re.sub('&','&amp;',xcfcc) + '</display-name>\n')
+                    fh.write('\t\t<display-name>' + convHTML(xcfcc) + '</display-name>\n')
                 elif 'chnum' in scheduleSort[station]:
                     xchnum = scheduleSort[station]['chnum']
                     fh.write('\t\t<display-name>' + xchnum + '</display-name>\n')
@@ -319,15 +327,15 @@ def mainRun(userdata):
                                 dd_progid = edict['epid']
                                 fh.write('\t\t<episode-num system=\"dd_progid\">' + dd_progid[:-4] + '.' + dd_progid[-4:] + '</episode-num>\n')
                                 if edict['epshow'] is not None:
-                                    fh.write('\t\t<title lang=\"' + lang + '\">' + re.sub('&','&amp;',edict['epshow']) + '</title>\n')
+                                    fh.write('\t\t<title lang=\"' + lang + '\">' + convHTML(edict['epshow']) + '</title>\n')
                                 if edict['eptitle'] is not None:
-                                    fh.write('\t\t<sub-title lang=\"'+ lang + '\">' + re.sub('&','&amp;', edict['eptitle']) + '</sub-title>\n')
+                                    fh.write('\t\t<sub-title lang=\"'+ lang + '\">' + convHTML(edict['eptitle']) + '</sub-title>\n')
                                 if xdesc == 'true':
                                     xdescSort = addXDetails(edict)
-                                    fh.write('\t\t<desc lang=\"' + lang + '\">' + re.sub('&','&amp;', xdescSort) + '</desc>\n')
+                                    fh.write('\t\t<desc lang=\"' + lang + '\">' + convHTML(xdescSort) + '</desc>\n')
                                 if xdesc == 'false':
                                     if edict['epdesc'] is not None:
-                                        fh.write('\t\t<desc lang=\"' + lang + '\">' + re.sub('&','&amp;', edict['epdesc']) + '</desc>\n')
+                                        fh.write('\t\t<desc lang=\"' + lang + '\">' + convHTML(edict['epdesc']) + '</desc>\n')
                                 if edict['epsn'] is not None and edict['epen'] is not None:
                                     fh.write("\t\t<episode-num system=\"onscreen\">" + 'S' + edict['epsn'].zfill(2) + 'E' + edict['epen'].zfill(2) + "</episode-num>\n")
                                     fh.write("\t\t<episode-num system=\"xmltv_ns\">" + str(int(edict['epsn'])-1) +  "." + str(int(edict['epen'])-1) + ".</episode-num>\n")

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -295,7 +295,8 @@ def mainRun(userdata):
                     xchfcc = scheduleSort[station]['chfcc']
                     xchnam = scheduleSort[station]['chnam']
                     fh.write('\t\t<display-name>' + xchnum + ' ' + convHTML(xchfcc) + '</display-name>\n')
-                    fh.write('\t\t<display-name>' + convTitleExcept(xchnam) + '</display-name>\n')
+                    if xchnam != "INDEPENDENT":
+                        fh.write('\t\t<display-name>' + convTitleExcept(xchnam) + '</display-name>\n')
                     fh.write('\t\t<display-name>' + convHTML(xchfcc) + '</display-name>\n')
                     fh.write('\t\t<display-name>' + xchnum + '</display-name>\n')
                 elif 'chfcc' in scheduleSort[station]:


### PR DESCRIPTION
First comment: it runs really well and it's really fast!  Nice work!

1. Using the following changes I am now able to manually call the script using python3
2. Also, in order for the title & description to be fully functional in TVH & Kodi all escape characters needs to be converted to legacy style HTML such as:
```
        data = data.replace('&','&amp;')
        data = data.replace('"','&quot;')
        data = data.replace("'",'&apos;')
        data = data.replace('<','&lt;')
        data = data.replace('>','&gt;')
```

Other opportunities for improvement:
- [x] When CC tag is found then `<subtitles type="teletext" />` can be added
- [x] Adding categories
- [x] Adding `<length units="minutes">60</length>` tag
- [x] Manage `premiere` and `last-chance` flags
- [x] Add real channel name

Language...I believe it can be better managed.  Issue is: if set in frech I believe it sets it for everything, which is not true at all.  I think any non-english channels should have a representative flag.  Then, having a category dictionary, the categories could be added for those channels in both languages (default `lang=en` + specific to that channel)

Food for thoughts:
- Create an external config xml file defining default language for non-english channels
- Create an external config xml file with a dictionary for categories
- When parsing channels, change the `lang=` flag based on the configuration, else set it to english
- When parsing categories for each channel, add both the english category name and it's default language equivalent with proper `lang=` tag.
