### PR TITLE
Add support for teletext, last-chance, premiere, length and credits tags

### DIFF
--- a/zap2epg.py
+++ b/zap2epg.py
@@ -702,17 +702,6 @@ def mainRun(userdata):
                 myear = "Released: " + edict['epyear'] + space
             if edict['eprating'] is not None:
                 ratings = edict['eprating'] + space
-            if edict['epflag'] != []:
-                flagList = edict['epflag']
-                new = ' - '.join(flagList).upper() + space
-            #if edict['epnew'] is not None:
-                #new = edict['epnew'] + space
-            #if edict['eplive'] is not None:
-                #new = edict['eplive'] + space
-            #if edict['epprem'] is not None:
-                #new = edict['epprem'] + space
-            #if edict['epfin'] is not None:
-                #new = edict['epfin'] + space
             if edict['eptags'] != []:
                 tagsList = edict['eptags']
                 cc = ' | '.join(tagsList).upper() + space
@@ -724,20 +713,6 @@ def mainRun(userdata):
                 e = re.sub('E', '', edict['epen'])
                 ef = "Episode " + str(int(e))
                 season = sf + " - " + ef + space
-            if edict['epcredits'] is not None:
-                cast = "Cast: "
-                castlist = ""
-                prev = None
-                EPcastList = []
-                for c in edict['epcredits']:
-                    EPcastList.append(c['name'])
-                for g in EPcastList:
-                    if prev is None:
-                        castlist = g
-                        prev = g
-                    else:
-                        castlist = castlist + ", " + g
-                cast = cast + castlist + space
             if edict['epshow'] is not None:
                 prog = edict['epshow'] + space
             if edict['eptitle'] is not None:

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -366,6 +366,14 @@ def mainRun(userdata):
                                     fh.write(f'\t\t<rating>\n\t\t\t<value>{edict["eprating"]}</value>\n\t\t</rating>\n')
                                 if edict['epstar'] is not None:
                                     fh.write(f'\t\t<star-rating>\n\t\t\t<value>{edict["epstar"]}/4</value>\n\t\t</star-rating>\n')
+                                if edict['epcredits'] is not None:
+                                   fh.write("\t\t<credits>\n")
+                                   for c in edict['epcredits']:
+                                        if c['assetId'] is not None:
+                                            fh.write('\t\t\t<' + c['role'].lower() + ' role="' + html.escape(c['characterName'], quote=True) + '" src="https://zap2it.tmsimg.com/assets/' + c['assetId'] + '">' + html.escape(c['name'], quote=True) + '</' + c['role'].lower() + '>\n')
+                                        else:
+                                            fh.write('\t\t\t<' + c['role'].lower() + ' role="' + html.escape(c['characterName'], quote=True) + '">' + html.escape(c['name'], quote=True) + '</' + c['role'].lower() + '>\n')
+                                   fh.write("\t\t</credits>\n")
                                 if edict['eptags'] is not None:
                                    if 'CC' in edict['eptags']:
                                         fh.write('\t\t<subtitles type="teletext" />\n')

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -380,8 +380,11 @@ def mainRun(userdata):
                                 if epgenre != '0':
                                    if edict['epfilter'] is not None and edict['epgenres'] is not None:
                                         genreNewList = genreSort(edict, epgenre, useHex)
+                                   elif edict['epfilter'] is not None:
+                                        genreNewList = edict['epfilter']
+                                   if genreNewList is not None and genreNewList != '':
                                         for genre in genreNewList:
-                                            genre = html.escape(genre, quote=True)
+                                            genre = html.escape(genre.replace('filter-', ''), quote=True)
                                             fh.write(f'\t\t<category lang=\"en\">{genre}</category>\n')
                                 fh.write("\t</programme>\n")
                                 episodeCount += 1

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -369,8 +369,8 @@ def mainRun(userdata):
                                 if edict['epcredits'] is not None:
                                    fh.write("\t\t<credits>\n")
                                    for c in edict['epcredits']:
-                                        if c['assetId'] is not None:
-                                            fh.write('\t\t\t<' + c['role'].lower() + ' role="' + html.escape(c['characterName'], quote=True) + '" src="https://zap2it.tmsimg.com/assets/' + c['assetId'] + '">' + html.escape(c['name'], quote=True) + '</' + c['role'].lower() + '>\n')
+                                        if c['assetId'] is not None and c['assetId'] != '':
+                                            fh.write('\t\t\t<' + c['role'].lower() + ' role="' + html.escape(c['characterName'], quote=True) + '" src="https://zap2it.tmsimg.com/assets/' + c['assetId'] + '.jpg">' + html.escape(c['name'], quote=True) + '</' + c['role'].lower() + '>\n')
                                         else:
                                             fh.write('\t\t\t<' + c['role'].lower() + ' role="' + html.escape(c['characterName'], quote=True) + '">' + html.escape(c['name'], quote=True) + '</' + c['role'].lower() + '>\n')
                                    fh.write("\t\t</credits>\n")

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -328,6 +328,8 @@ def mainRun(userdata):
                                     if edict['epdesc'] is not None:
                                         epdesc = html.escape(f"{edict['epdesc']}\nLang: {lang}", quote=True)
                                         fh.write(f'\t\t<desc lang="{lang}">{epdesc}</desc>\n')
+                                if edict['eplength'] is not None:
+                                    fh.write('\t\t<length units="minutes">' + edict['eplength'] + '</length>\n')
                                 if edict['epsn'] is not None and edict['epen'] is not None:
                                     fh.write(f'\t\t<episode-num system=\"onscreen\">S{edict["epsn"].zfill(2)}E{edict["epen"].zfill(2)}</episode-num>\n')
                                     fh.write(f'\t\t<episode-num system=\"xmltv_ns\">{str(int(edict["epsn"])-1)}.{str(int(edict["epen"])-1)}.</episode-num>\n')

--- a/zap2epg.py
+++ b/zap2epg.py
@@ -352,14 +352,21 @@ def mainRun(userdata):
                                         fh.write(f'start=\"{convTime(edict["epoad"])} {TZoffset}\" ')
                                     fh.write("/>\n")
                                 if edict['epflag'] is not None:
-                                    if 'New' in edict['epflag']:
-                                        fh.write("\t\t<new />\n")
+                                    if 'Finale' in edict['epflag']:
+                                        fh.write("\t\t<last-chance />\n")
                                     if 'Live' in edict['epflag']:
                                         fh.write("\t\t<live />\n")
+                                    if 'New' in edict['epflag']:
+                                        fh.write("\t\t<new />\n")
+                                    if 'Premiere' in edict['epflag']:
+                                        fh.write("\t\t<premiere />\n")
                                 if edict['eprating'] is not None:
                                     fh.write(f'\t\t<rating>\n\t\t\t<value>{edict["eprating"]}</value>\n\t\t</rating>\n')
                                 if edict['epstar'] is not None:
                                     fh.write(f'\t\t<star-rating>\n\t\t\t<value>{edict["epstar"]}/4</value>\n\t\t</star-rating>\n')
+                                if edict['eptags'] is not None:
+                                   if 'CC' in edict['eptags']:
+                                        fh.write('\t\t<subtitles type="teletext" />\n')
                                 if epgenre != '0':
                                    if edict['epfilter'] is not None and edict['epgenres'] is not None:
                                         genreNewList = genreSort(edict, epgenre, useHex)


### PR DESCRIPTION
Following set of changes add xml support for `teletext`, `last-chance`, `premiere`, `length` and `credits` tags.  It also ensures to have minimal category info provided when `xdetails=false`.

Credits tags appears such as:
```
                <credits>
                        <actor role="Fuller" src="https://zap2it.tmsimg.com/assets/60451_v9_bf.jpg">Steve Zahn</actor>
                        <actor role="Lewis" src="https://zap2it.tmsimg.com/assets/77718_v9_ba.jpg">Paul Walker</actor>
                        <actor role="Venna">Leelee Sobieski</actor>
                        <actor role="Sheriff Ritter">Jim Beaver</actor>
                </credits>
```

This allows removing duplicated values as entirely managed through xmltv and compatible with both TVH and Kodi.

Lastly, considering there is once again movement on this repository, this is a first PR in hope to sync back some key elements from my own fork that has been running well over the past 4-years.  Final intent is to be able to re-package this master tree into SynoCommunity TVH package (which I am mainainer of) instead of using my current fork as I've been doing over the last few years.

Orignal patchset I maintained can be found at https://github.com/th0ma7/script.module.zap2epg/tree/Python3-th0ma7-updates - Note that I intent to propose only a subset of those patches, provided in different PR progressively, as long as there is actual interest.

Much thnx in advance for considering theses changes.